### PR TITLE
Enable Evil mode

### DIFF
--- a/init.el
+++ b/init.el
@@ -88,6 +88,13 @@
   :config
   (setq which-key-idle-delay 1))
 
+(use-package evil
+  :init
+  (setq evil-want-integration t)
+  (setq evil-want-keybinding nil)
+  :config
+  (evil-mode 1))
+
 ;; Keybindings
 (global-set-key (kbd "C-x r") 'recentf-open-files)
 (global-set-key (kbd "<escape>") 'keyboard-escape-quit) ; ESC quits prompts


### PR DESCRIPTION
## Summary
- set up `evil` for Vim-like keybindings

## Testing
- `emacs --batch -f batch-byte-compile init.el` *(fails: emacs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448b110a8c8322adf3ce085dd9221c