### PR TITLE
Add split-window shortcuts

### DIFF
--- a/init.el
+++ b/init.el
@@ -79,7 +79,9 @@
   :prefix "SPC")
 
 (my-leader-def
-  "n j j" '(org-journal-new-entry :which-key "new journal entry"))
+  "n j j" '(org-journal-new-entry :which-key "new journal entry")
+  "-" '(split-window-below :which-key "split horizontally")
+  "|" '(split-window-right :which-key "split vertically"))
 
 ;;; Evil mode
 (use-package evil


### PR DESCRIPTION
## Summary
- add convenience split-window bindings to the leader key

## Testing
- `emacs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684799f04074832286c484eb4bfc41d6