### PR TITLE
Add basic spell checking config

### DIFF
--- a/init.el
+++ b/init.el
@@ -94,3 +94,12 @@
 (global-set-key (kbd "C-x r") 'recentf-open-files)
 (global-set-key (kbd "<escape>") 'keyboard-escape-quit)
 
+;;; Spell checking
+(use-package flyspell
+  :hook ((text-mode . flyspell-mode)
+         (prog-mode . flyspell-prog-mode))
+  :init
+  (setq ispell-program-name (or (executable-find "aspell")
+                                (executable-find "hunspell"))
+        ispell-dictionary "en_US"))
+


### PR DESCRIPTION
## Summary
- add a minimal flyspell setup for automatic spell checking

## Testing
- `emacs --batch -Q -l init.el` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a35bd99608322b19d10a1a6ff6abb