### PR TITLE
Load evil mode eagerly

### DIFF
--- a/init.el
+++ b/init.el
@@ -109,14 +109,17 @@
 
 ;;; Evil mode
 (use-package evil
+  :demand t
   :init
   (setq evil-want-integration t
         evil-want-keybinding nil)
-  :config (evil-mode 1))
+  :config
+  (evil-mode 1))
 
 ;;; Evil Collection - additional keybindings for Evil mode
 (use-package evil-collection
   :after evil
+  :demand t
   :custom (evil-collection-mode-list 'all)
   :config
   (evil-collection-init))


### PR DESCRIPTION
## Summary
- ensure `evil` and `evil-collection` load on startup

## Testing
- `apt-get update`
- `apt-get install -y emacs-nox` *(fails: debconf requires noninteractive settings)*

------
https://chatgpt.com/codex/tasks/task_e_684e214093c88322a8e327219e863d5c