### PR TITLE
Fix org journal entry behavior

### DIFF
--- a/init.el
+++ b/init.el
@@ -142,10 +142,14 @@
 ;;; Org-journal
 (use-package org-journal
   :custom
+  ;; Store journal files in a dedicated directory
   (org-journal-dir (expand-file-name "~/Documents/Journal/"))
-  (org-journal-file-format "%B %d %Y.org")
+  ;; Use a numeric filename so org-journal can parse dates correctly
+  (org-journal-file-format "%Y-%m-%d.org")
   (org-journal-date-format "%B %d, %Y")
-  (org-journal-file-header "%B %d, %Y\n\n"))
+  (org-journal-file-header "%B %d, %Y\n\n")
+  ;; Open journal entries in the current window
+  (org-journal-find-file 'find-file))
 
 ;;; Key bindings
 (my-leader-def


### PR DESCRIPTION
## Summary
- ensure org-journal does not open entries in other frames
- use numeric filenames for journal files so org-journal parses dates correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862b83e8bb88322ada7cb00d3a48dcb