### PR TITLE
Fix org-journal header

### DIFF
--- a/init.el
+++ b/init.el
@@ -146,7 +146,8 @@
   (org-journal-dir (expand-file-name "~/Documents/Journal/"))
   ;; Use a numeric filename so org-journal can parse dates correctly
   (org-journal-file-format "%Y-%m-%d.org")
-  (org-journal-date-format "%B %d, %Y")
+  (org-journal-date-prefix "")
+  (org-journal-date-format (lambda (_time) "* Mood:"))
   (org-journal-file-header "%B %d, %Y\n\n")
   ;; Open journal entries in the current window
   (org-journal-find-file 'find-file))


### PR DESCRIPTION
## Summary
- avoid duplicated date headings in org-journal

## Testing
- `emacs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bf62c5f48322946f0d7b4f002cc3