### PR TITLE
Set journal timestamps to 12‑hour time

### DIFF
--- a/init.el
+++ b/init.el
@@ -148,6 +148,8 @@
   (org-journal-file-format "%Y-%m-%d.org")
   (org-journal-date-prefix "")
   (org-journal-date-format (lambda (_time) "* Mood:"))
+  ;; Prefix each entry with a 12-hour timestamp
+  (org-journal-time-format "%I:%M %p ")
   (org-journal-file-header "%B %d, %Y\n\n")
   ;; Open journal entries in the current window
   (org-journal-find-file 'find-file))


### PR DESCRIPTION
## Summary
- update org-journal settings
- prefix entries with 12 hour time using `%I:%M %p`

## Testing
- `emacs -Q --batch -f batch-byte-compile init.el` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c5d1dc6483228de6c108257adb4c