### PR TITLE
Update journal layout

### DIFF
--- a/init.el
+++ b/init.el
@@ -147,8 +147,9 @@
   ;; Use a numeric filename so org-journal can parse dates correctly
   (org-journal-file-format "%Y-%m-%d.org")
   (org-journal-date-prefix "")
-  (org-journal-date-format (lambda (_time) "* Mood:"))
-  ;; Prefix each entry with a 12-hour timestamp
+  (org-journal-date-format "")
+  ;; Prefix each entry with a single-star timestamp header
+  (org-journal-time-prefix "* ")
   (org-journal-time-format "%I:%M %p ")
   (org-journal-file-header "%B %d, %Y\n\n")
   ;; Open journal entries in the current window


### PR DESCRIPTION
## Summary
- adjust `org-journal` config so journal entries start directly with the time
- set `org-journal-time-prefix` to a single `*`

## Testing
- `emacs` not installed; cannot run byte-compilation

------
https://chatgpt.com/codex/tasks/task_e_6862caa28c5c832297d4c6e762fe4f08