### PR TITLE
Remove timestamp from new journal entries

### DIFF
--- a/init.el
+++ b/init.el
@@ -148,9 +148,6 @@
   (org-journal-file-format "%Y-%m-%d.org")
   (org-journal-date-prefix "")
   (org-journal-date-format "")
-  ;; Prefix each entry with a single-star timestamp header
-  (org-journal-time-prefix "* ")
-  (org-journal-time-format "%I:%M %p ")
   (org-journal-file-header "%B %d, %Y\n\n")
   ;; Open journal entries in the current window
   (org-journal-find-file 'find-file))


### PR DESCRIPTION
## Summary
- configure `org-journal` to suppress timestamps by removing related settings

## Testing
- `emacs --batch -f batch-byte-compile init.el`

------
https://chatgpt.com/codex/tasks/task_e_6862cf72632c83229908e25aea9e6a3a