### PR TITLE
Fix org-journal date format error

### DIFF
--- a/init.el
+++ b/init.el
@@ -147,7 +147,7 @@
   ;; Use a numeric filename so org-journal can parse dates correctly
   (org-journal-file-format "%Y-%m-%d.org")
   (org-journal-date-prefix "")
-  (org-journal-date-format "")
+  (org-journal-date-format "%B %d, %Y")
   (org-journal-file-header "%B %d, %Y\n\n")
   ;; Open journal entries in the current window
   (org-journal-find-file 'find-file))


### PR DESCRIPTION
## Summary
- ensure `org-journal-date-format` is not empty to prevent errors in the modeline

## Testing
- `emacs --batch -l init.el` *(fails: `bash: emacs: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862d5b530a083229f46eb4634d3483b