### PR TITLE
Fix modeline overlap by setting scroll margin

### DIFF
--- a/init.el
+++ b/init.el
@@ -24,6 +24,9 @@
 (tooltip-mode -1)
 (set-fringe-mode 10)
 (global-visual-line-mode 1)
+;; Keep one line visible below the cursor to avoid the mode line
+;; obscuring text near the bottom of the buffer.
+(setq scroll-margin 1)
 (add-to-list 'default-frame-alist '(font . "Iosevka-22"))
 (load-theme 'misterioso t)
 


### PR DESCRIPTION
## Summary
- keep one line visible below the cursor to prevent the mode line from covering text

## Testing
- `emacs --batch -q -l init.el` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654bc0638c83228bb5b07c7ce9770e