### PR TITLE
Fix Evil cursor initialization

### DIFF
--- a/init.el
+++ b/init.el
@@ -197,11 +197,11 @@
   :demand t
   :init
   (setq evil-want-integration t
-        evil-want-keybinding nil)
-  :config
-  (setq evil-normal-state-cursor 'box
+        evil-want-keybinding nil
+        evil-normal-state-cursor 'box
         evil-insert-state-cursor 'bar
         evil-visual-state-cursor 'hollow)
+  :config
   (evil-mode 1))
 
 (use-package evil-collection


### PR DESCRIPTION
## Summary
- set Evil cursor styles during `:init` so they apply before `evil-mode` starts

## Testing
- `apt-get update` *(fails: mise.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883cf0d169083229790255906ffa21e