### PR TITLE
Configure blinking terminal cursor in insert mode

### DIFF
--- a/init.el
+++ b/init.el
@@ -203,14 +203,16 @@
         evil-visual-state-cursor 'hollow)
   :config
   (evil-mode 1)
-  (defun my-enable-blink-cursor ()
-    "Enable cursor blinking."
-    (blink-cursor-mode 1))
-  (defun my-disable-blink-cursor ()
-    "Disable cursor blinking."
+  (defun my-cursor-normal-state ()
+    "Use a non-blinking box cursor."
+    (setq cursor-type 'box)
     (blink-cursor-mode 0))
-  (add-hook 'evil-insert-state-entry-hook #'my-enable-blink-cursor)
-  (add-hook 'evil-insert-state-exit-hook #'my-disable-blink-cursor))
+  (defun my-cursor-insert-state ()
+    "Use a blinking bar cursor."
+    (setq cursor-type 'bar)
+    (blink-cursor-mode 1))
+  (add-hook 'evil-insert-state-entry-hook #'my-cursor-insert-state)
+  (add-hook 'evil-insert-state-exit-hook #'my-cursor-normal-state))
 
 (use-package evil-collection
   :after evil

--- a/init.el
+++ b/init.el
@@ -22,7 +22,7 @@
 (tool-bar-mode -1)
 (scroll-bar-mode -1)
 (tooltip-mode -1)
-(blink-cursor-mode 1)
+(blink-cursor-mode 0)
 (set-fringe-mode 10)
 (global-visual-line-mode 1)
 ;; Keep one line visible below the cursor to avoid the mode line
@@ -202,7 +202,15 @@
         evil-insert-state-cursor 'bar
         evil-visual-state-cursor 'hollow)
   :config
-  (evil-mode 1))
+  (evil-mode 1)
+  (defun my-enable-blink-cursor ()
+    "Enable cursor blinking."
+    (blink-cursor-mode 1))
+  (defun my-disable-blink-cursor ()
+    "Disable cursor blinking."
+    (blink-cursor-mode 0))
+  (add-hook 'evil-insert-state-entry-hook #'my-enable-blink-cursor)
+  (add-hook 'evil-insert-state-exit-hook #'my-disable-blink-cursor))
 
 (use-package evil-collection
   :after evil


### PR DESCRIPTION
## Summary
- disable global blink-cursor-mode
- blink only in insert state

## Testing
- `emacs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883d4ec10c483229fb483372b45a96e