### PR TITLE
Fix dashboard recent files

### DIFF
--- a/init.el
+++ b/init.el
@@ -32,10 +32,6 @@
 (load-theme 'misterioso t)
 
 ;;; File handling
-(recentf-mode 1)
-(setq recentf-max-saved-items 100
-      recentf-auto-cleanup 'never)
-(add-hook 'kill-emacs-hook #'recentf-save-list)
 (save-place-mode 1)
 (windmove-default-keybindings)
 (global-auto-revert-mode 1)
@@ -69,6 +65,12 @@
   :config
   (setq auto-save-file-name-transforms
         `((".*" ,(no-littering-expand-var-file-name "auto-save/") t))))
+
+;;; Recent files
+(recentf-mode 1)
+(setq recentf-max-saved-items 100
+      recentf-auto-cleanup 'never)
+(add-hook 'kill-emacs-hook #'recentf-save-list)
 
 ;;; UI packages
 (use-package command-log-mode)


### PR DESCRIPTION
## Summary
- ensure recentf-mode initializes after no-littering so the dashboard picks up recent files

## Testing
- `git status --short`
- `git log -1 --stat`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688647bf57b08322992ba23474bd5180