### PR TITLE
Enable visual state when selecting text with the mouse

### DIFF
--- a/init.el
+++ b/init.el
@@ -229,6 +229,17 @@
                                 (executable-find "hunspell"))
         ispell-dictionary "en_US"))
 
+;;; Visual selection with the mouse
+(defun my/evil-visual-on-mouse-select ()
+  "Enter `evil-visual-state` when selecting text with the mouse."
+  (when (and (bound-and-true-p evil-mode)
+             (evil-normal-state-p)
+             (memq this-command '(mouse-set-region mouse-drag-region)))
+    ;; Use inclusive selection to mimic Vim's visual behaviour
+    (evil-visual-select (region-beginning) (region-end) 'inclusive)))
+
+(add-hook 'activate-mark-hook #'my/evil-visual-on-mouse-select)
+
 ;;; PDF tools
 (use-package pdf-tools
   :mode ("\\.pdf\\'" . pdf-view-mode)


### PR DESCRIPTION
## Summary
- hook into `activate-mark-hook` to detect mouse selections
- enter `evil-visual-state` whenever text is selected using the mouse

## Testing
- `emacs` not installed, so config not executed

------
https://chatgpt.com/codex/tasks/task_e_6888e0cf42c48322a99bd98f4907590d