### PR TITLE
Update Evil movement keys for visual lines

### DIFF
--- a/init.el
+++ b/init.el
@@ -202,11 +202,18 @@
   :init
   (setq evil-want-integration t
         evil-want-keybinding nil
+        evil-respect-visual-line-mode t
         evil-normal-state-cursor 'box
         evil-insert-state-cursor 'bar
         evil-visual-state-cursor 'hollow)
   :config
   (evil-mode 1)
+  (evil-global-set-key 'motion (kbd "h") #'evil-backward-char)
+  (evil-global-set-key 'motion (kbd "j") #'evil-next-visual-line)
+  (evil-global-set-key 'motion (kbd "k") #'evil-previous-visual-line)
+  (evil-global-set-key 'motion (kbd "l") #'evil-forward-char)
+  (evil-global-set-key 'motion (kbd "0") #'evil-beginning-of-line)
+  (evil-global-set-key 'motion (kbd "$") #'evil-end-of-line)
 )
 
 (use-package evil-collection


### PR DESCRIPTION
## Summary
- enable `evil-respect-visual-line-mode`
- remap motion keys to operate on visual lines
- ensure `0` and `$` jump to real line boundaries

## Testing
- `git status --short`
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888f1d8a17883228cf25f1034c5643d