### PR TITLE
Increase default font size

### DIFF
--- a/init.el
+++ b/init.el
@@ -30,7 +30,7 @@
 ;; Keep one line visible below the cursor to avoid the mode line
 ;; obscuring text near the bottom of the buffer.
 (setq scroll-margin 1)
-(add-to-list 'default-frame-alist '(font . "Iosevka-22"))
+(add-to-list 'default-frame-alist '(font . "Iosevka-26"))
 (load-theme 'misterioso t)
 
 ;;; File handling


### PR DESCRIPTION
## Summary
- bump the Emacs default frame font from 23 to 26

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68897a899e3883229ec36552bb849226