### PR TITLE
Fix Evil visual mode for mouse selection

### DIFF
--- a/init.el
+++ b/init.el
@@ -237,15 +237,15 @@
         ispell-dictionary "en_US"))
 
 ;;; Visual selection with the mouse
-(defun my/evil-visual-on-mouse-select ()
-  "Enter `evil-visual-state` when selecting text with the mouse."
+(defun my/evil-activate-visual-after-mouse (event)
+  "Enter visual state after selecting text with the mouse."
   (when (and (bound-and-true-p evil-mode)
              (evil-normal-state-p)
-             (memq this-command '(mouse-set-region mouse-drag-region)))
+             (region-active-p))
     ;; Use inclusive selection to mimic Vim's visual behaviour
     (evil-visual-select (region-beginning) (region-end) 'inclusive)))
 
-(add-hook 'activate-mark-hook #'my/evil-visual-on-mouse-select)
+(advice-add 'mouse-drag-region :after #'my/evil-activate-visual-after-mouse)
 
 ;;; PDF tools
 (use-package pdf-tools


### PR DESCRIPTION
## Summary
- add advice for mouse-drag-region to enter evil visual mode automatically

## Testing
- `apt-get update`
- `apt-get install -y emacs` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_688aa65712948322bd0493faada213b4